### PR TITLE
Ensure all permissioned methods have top level authorization

### DIFF
--- a/contracts/LRTDepositPool.sol
+++ b/contracts/LRTDepositPool.sol
@@ -119,15 +119,7 @@ contract LRTDepositPool is ILRTDepositPool, LRTConfigRoleChecker, PausableUpgrad
     /// @param asset Asset address
     /// @param amount Asset amount
     /// @return primeEthAmount Amount of primeETH to mint
-    function getMintAmount(
-        address asset,
-        uint256 amount
-    )
-        public
-        view
-        override
-        returns (uint256 primeEthAmount)
-    {
+    function getMintAmount(address asset, uint256 amount) public view override returns (uint256 primeEthAmount) {
         // setup oracle contract
         address lrtOracleAddress = lrtConfig.getContract(LRTConstants.LRT_ORACLE);
         ILRTOracle lrtOracle = ILRTOracle(lrtOracleAddress);
@@ -297,7 +289,10 @@ contract LRTDepositPool is ILRTDepositPool, LRTConfigRoleChecker, PausableUpgrad
     /// @notice remove many node delegator contracts from queue
     /// @dev calls internally removeNodeDelegatorContractFromQueue which is only callable by LRT admin
     /// @param nodeDelegatorContracts Array of NodeDelegator contract addresses
-    function removeManyNodeDelegatorContractsFromQueue(address[] calldata nodeDelegatorContracts) external {
+    function removeManyNodeDelegatorContractsFromQueue(address[] calldata nodeDelegatorContracts)
+        external
+        onlyLRTAdmin
+    {
         uint256 length = nodeDelegatorContracts.length;
 
         for (uint256 i; i < length;) {


### PR DESCRIPTION
`removeManyNodeDelegatorContractsFromQueue` did not have external authentication before running. In theory this is handled by the `removeNodeDelegatorContractFromQueue` function that it calls, but it's still the kind of thing that keeps me up at night.

Also ran `forge fmt` on the file.