### PR TITLE
Remove unused/duplicate code in token contract

### DIFF
--- a/contracts/LRTDepositPool.sol
+++ b/contracts/LRTDepositPool.sol
@@ -119,15 +119,7 @@ contract LRTDepositPool is ILRTDepositPool, LRTConfigRoleChecker, PausableUpgrad
     /// @param asset Asset address
     /// @param amount Asset amount
     /// @return primeEthAmount Amount of primeETH to mint
-    function getMintAmount(
-        address asset,
-        uint256 amount
-    )
-        public
-        view
-        override
-        returns (uint256 primeEthAmount)
-    {
+    function getMintAmount(address asset, uint256 amount) public view override returns (uint256 primeEthAmount) {
         // setup oracle contract
         address lrtOracleAddress = lrtConfig.getContract(LRTConstants.LRT_ORACLE);
         ILRTOracle lrtOracle = ILRTOracle(lrtOracleAddress);

--- a/contracts/PrimeStakedETH.sol
+++ b/contracts/PrimeStakedETH.sol
@@ -17,10 +17,8 @@ contract PrimeStakedETH is Initializable, LRTConfigRoleChecker, ERC20Upgradeable
     }
 
     /// @dev Initializes the contract
-    /// @param admin Admin address
     /// @param lrtConfigAddr LRT config address
-    function initialize(address admin, address lrtConfigAddr) external initializer {
-        UtilLib.checkNonZeroAddress(admin);
+    function initialize(address lrtConfigAddr) external initializer {
         UtilLib.checkNonZeroAddress(lrtConfigAddr);
 
         __ERC20_init("Prime Staked ETH", "primeETH");
@@ -53,14 +51,5 @@ contract PrimeStakedETH is Initializable, LRTConfigRoleChecker, ERC20Upgradeable
     /// @dev Only callable by the primeETH admin. Contract must be paused
     function unpause() external onlyLRTAdmin {
         _unpause();
-    }
-
-    /// @notice Updates the LRT config contract
-    /// @dev only callable by the primeETH admin
-    /// @param _lrtConfig the new LRT config contract
-    function updateLRTConfig(address _lrtConfig) external override onlyLRTAdmin {
-        UtilLib.checkNonZeroAddress(_lrtConfig);
-        lrtConfig = ILRTConfig(_lrtConfig);
-        emit UpdatedLRTConfig(_lrtConfig);
     }
 }

--- a/contracts/cross-chain/PrimeStakedETHRateReceiver.sol
+++ b/contracts/cross-chain/PrimeStakedETHRateReceiver.sol
@@ -4,7 +4,8 @@ pragma solidity 0.8.21;
 import { CrossChainRateReceiver } from "./CrossChainRateReceiver.sol";
 
 /// @title primeETH cross chain rate receiver
-/// @notice Receives the primeETH rate from a provider contract on a different chain than the one this contract is deployed
+/// @notice Receives the primeETH rate from a provider contract on a different chain than the one this contract is
+/// deployed
 /// on
 contract PrimeStakedETHRateReceiver is CrossChainRateReceiver {
     constructor(uint16 _srcChainId, address _rateProvider, address _layerZeroEndpoint) {

--- a/script/foundry-scripts/DeployLRT.s.sol
+++ b/script/foundry-scripts/DeployLRT.s.sol
@@ -196,7 +196,7 @@ contract DeployLRT is Script {
 
         PRETHProxy = PrimeStakedETH(proxyFactory.create(address(primeETHImplementation), address(proxyAdmin), salt));
         // init PrimeStakedETH
-        PRETHProxy.initialize(deployerAddress, address(lrtConfigProxy));
+        PRETHProxy.initialize(address(lrtConfigProxy));
 
         lrtDepositPoolProxy = LRTDepositPool(
             payable(proxyFactory.create(address(lrtDepositPoolImplementation), address(proxyAdmin), salt))

--- a/script/foundry-scripts/DeployMinimal.s.sol
+++ b/script/foundry-scripts/DeployMinimal.s.sol
@@ -77,7 +77,7 @@ contract DeployMinimal is Script {
 
         PRETHProxy = PrimeStakedETH(proxyFactory.create(address(primeETHImplementation), address(proxyAdmin), salt));
         // init PrimeStakedETH
-        PRETHProxy.initialize(deployerAddress, address(lrtConfigProxy));
+        PRETHProxy.initialize(address(lrtConfigProxy));
 
         console.log("LRTConfig proxy deployed at: ", address(lrtConfigProxy));
         console.log("PrimeStakedETH proxy deployed at: ", address(PRETHProxy));

--- a/script/foundry-scripts/TransferOwnership.s.sol
+++ b/script/foundry-scripts/TransferOwnership.s.sol
@@ -12,7 +12,7 @@ contract TransferOwnership is Script {
     address public deployerAddress;
     ProxyAdmin public proxyAdmin;
     LRTConfig public lrtConfigProxy;
-   
+
     function run() external {
         vm.startBroadcast();
 

--- a/test/LRTDepositPoolTest.t.sol
+++ b/test/LRTDepositPoolTest.t.sol
@@ -71,7 +71,7 @@ contract LRTDepositPoolTest is BaseTest, PrimeStakedETHTest {
         lrtDepositPool = LRTDepositPool(payable(contractProxy));
 
         // initialize PrimeStakedETHTest. LRTCOnfig is already initialized in PrimeStakedETHTest
-        preth.initialize(address(admin), address(lrtConfig));
+        preth.initialize(address(lrtConfig));
         vm.startPrank(admin);
         // add prETH to LRT config
         lrtConfig.setPrimeETH(address(preth));

--- a/test/PrimeStakedETHTest.t.sol
+++ b/test/PrimeStakedETHTest.t.sol
@@ -29,18 +29,13 @@ contract PrimeStakedETHTest is BaseTest, LRTConfigTest {
 }
 
 contract PRETHInitialize is PrimeStakedETHTest {
-    function test_RevertWhenAdminIsZeroAddress() external {
-        vm.expectRevert(UtilLib.ZeroAddressNotAllowed.selector);
-        preth.initialize(address(0), address(lrtConfig));
-    }
-
     function test_RevertWhenLRTConfigIsZeroAddress() external {
         vm.expectRevert(UtilLib.ZeroAddressNotAllowed.selector);
-        preth.initialize(address(admin), address(0));
+        preth.initialize(address(0));
     }
 
     function test_InitializeContractsVariables() external {
-        preth.initialize(address(admin), address(lrtConfig));
+        preth.initialize(address(lrtConfig));
 
         assertTrue(lrtConfig.hasRole(LRTConstants.DEFAULT_ADMIN_ROLE, admin), "Admin address is not set");
         assertEq(address(lrtConfig), address(preth.lrtConfig()), "LRT config address is not set");
@@ -56,7 +51,7 @@ contract PRETHMint is PrimeStakedETHTest {
     function setUp() public override {
         super.setUp();
 
-        preth.initialize(address(admin), address(lrtConfig));
+        preth.initialize(address(lrtConfig));
 
         vm.startPrank(admin);
         lrtConfig.grantRole(LRTConstants.MANAGER, manager);
@@ -109,7 +104,7 @@ contract PRETHBurnFrom is PrimeStakedETHTest {
 
     function setUp() public override {
         super.setUp();
-        preth.initialize(address(admin), address(lrtConfig));
+        preth.initialize(address(lrtConfig));
 
         vm.startPrank(admin);
         lrtConfig.grantRole(LRTConstants.MANAGER, manager);
@@ -154,7 +149,7 @@ contract PRETHBurnFrom is PrimeStakedETHTest {
 contract PRETHPause is PrimeStakedETHTest {
     function setUp() public override {
         super.setUp();
-        preth.initialize(address(admin), address(lrtConfig));
+        preth.initialize(address(lrtConfig));
 
         vm.startPrank(admin);
         lrtConfig.grantRole(LRTConstants.MANAGER, manager);
@@ -193,7 +188,7 @@ contract PRETHPause is PrimeStakedETHTest {
 contract PRETHUnpause is PrimeStakedETHTest {
     function setUp() public override {
         super.setUp();
-        preth.initialize(address(admin), address(lrtConfig));
+        preth.initialize(address(lrtConfig));
 
         vm.startPrank(admin);
         lrtConfig.grantRole(LRTConstants.MANAGER, admin);
@@ -233,7 +228,7 @@ contract PRETHUnpause is PrimeStakedETHTest {
 contract PRETHUpdateLRTConfig is PrimeStakedETHTest {
     function setUp() public override {
         super.setUp();
-        preth.initialize(address(admin), address(lrtConfig));
+        preth.initialize(address(lrtConfig));
     }
 
     function test_RevertWhenCallerIsNotLRTAdmin() external {

--- a/test/integration/LRTIntegrationTest.t.sol
+++ b/test/integration/LRTIntegrationTest.t.sol
@@ -643,7 +643,7 @@ contract LRTIntegrationTest is Test {
     function test_PRETHIsAlreadyInitialized() public {
         // attempt to initialize PrimeStakedETH again reverts
         vm.expectRevert("Initializable: contract is already initialized");
-        preth.initialize(address(admin), address(lrtConfig));
+        preth.initialize(address(lrtConfig));
     }
 
     function test_RevertWhenCallerIsNotLRTManager() external {


### PR DESCRIPTION
PrimeStakedETH has an admin address in initialize() method that is never used. Tests also pass without it.

PrimeStakedETH also duplicates and shadows the `updateLRTConfig` from `LRTConfigRoleChecker`. This could bite us if we ever changed the functionality in `LRTConfigRoleChecker` and expected it to apply to all contracts.

Also ran forge fmt on all files. (only two minor changes)