### PR TITLE
Make oracle changing require admin

### DIFF
--- a/contracts/LRTOracle.sol
+++ b/contracts/LRTOracle.sol
@@ -87,14 +87,7 @@ contract LRTOracle is ILRTOracle, LRTConfigRoleChecker, Initializable {
     /// @dev add/update the price oracle of any supported asset
     /// @dev only LRTManager is allowed
     /// @param asset asset address for which oracle price needs to be added/updated
-    function updatePriceOracleFor(
-        address asset,
-        address priceOracle
-    )
-        external
-        onlyLRTManager
-        onlySupportedAsset(asset)
-    {
+    function updatePriceOracleFor(address asset, address priceOracle) external onlyLRTAdmin onlySupportedAsset(asset) {
         UtilLib.checkNonZeroAddress(priceOracle);
         assetPriceOracle[asset] = priceOracle;
         emit AssetPriceOracleUpdate(asset, priceOracle);

--- a/test/LRTOracleTest.t.sol
+++ b/test/LRTOracleTest.t.sol
@@ -101,21 +101,21 @@ contract LRTOracleSetPriceOracle is LRTOracleTest {
 
     function test_RevertWhenCallerIsNotLRTManager() external {
         vm.startPrank(alice);
-        vm.expectRevert(ILRTConfig.CallerNotLRTConfigManager.selector);
+        vm.expectRevert(ILRTConfig.CallerNotLRTConfigAdmin.selector);
         lrtOracle.updatePriceOracleFor(address(ethX), address(priceOracle));
         vm.stopPrank();
     }
 
     function test_RevertWhenAssetIsNotSupported() external {
         address randomAddress = address(0x123);
-        vm.startPrank(manager);
+        vm.startPrank(admin);
         vm.expectRevert(ILRTConfig.AssetNotSupported.selector);
         lrtOracle.updatePriceOracleFor(randomAddress, address(priceOracle));
         vm.stopPrank();
     }
 
     function test_RevertWhenPriceOracleIsZero() external {
-        vm.startPrank(manager);
+        vm.startPrank(admin);
         vm.expectRevert(UtilLib.ZeroAddressNotAllowed.selector);
         lrtOracle.updatePriceOracleFor(address(ethX), address(0));
         vm.stopPrank();
@@ -124,7 +124,7 @@ contract LRTOracleSetPriceOracle is LRTOracleTest {
     function test_SetAssetPriceFeed() external {
         assertEq(lrtOracle.assetPriceOracle(address(ethX)), address(0));
 
-        vm.startPrank(manager);
+        vm.startPrank(admin);
         expectEmit();
         emit AssetPriceOracleUpdate(address(ethX), address(priceOracle));
         lrtOracle.updatePriceOracleFor(address(ethX), address(priceOracle));
@@ -142,7 +142,7 @@ contract LRTOracleFetchAssetPrice is LRTOracleTest {
         lrtOracle.initialize(address(lrtConfig));
         priceOracle = new MockPriceOracle();
 
-        vm.prank(manager);
+        vm.prank(admin);
         lrtOracle.updatePriceOracleFor(address(ethX), address(priceOracle));
     }
 
@@ -167,7 +167,7 @@ contract LRTOracleFetchPRETHPrice is LRTOracleTest {
         lrtOracle.initialize(address(lrtConfig));
         priceOracle = new MockPriceOracle();
 
-        vm.startPrank(manager);
+        vm.startPrank(admin);
         lrtOracle.updatePriceOracleFor(address(ethX), address(priceOracle));
         lrtOracle.updatePriceOracleFor(address(stETH), address(priceOracle));
         vm.stopPrank();


### PR DESCRIPTION
Currently changing the oracle requires only manager permissions. Ideally the manager permissions do not allow stealing protocol funds. Since oracle changes could steal from users, this should be at admin permission levels.