### PR TITLE
Add ability for DepositPool and NodeDelegator to opt in for OETH rebasing

### DIFF
--- a/contracts/LRTDepositPool.sol
+++ b/contracts/LRTDepositPool.sol
@@ -9,6 +9,7 @@ import { IPrimeETH } from "./interfaces/IPrimeETH.sol";
 import { ILRTOracle } from "./interfaces/ILRTOracle.sol";
 import { INodeDelegator } from "./interfaces/INodeDelegator.sol";
 import { ILRTDepositPool } from "./interfaces/ILRTDepositPool.sol";
+import { IOETH } from "./interfaces/IOETH.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
@@ -408,6 +409,11 @@ contract LRTDepositPool is ILRTDepositPool, LRTConfigRoleChecker, PausableUpgrad
     /// @dev Returns to normal state. Contract must be paused
     function unpause() external onlyLRTAdmin {
         _unpause();
+    }
+
+    /// @dev opts in for rebase so the asset's token balance will increase
+    function optIn(address asset) external onlyLRTAdmin onlySupportedAsset(asset) {
+        IOETH(asset).rebaseOptIn();
     }
 
     receive() external payable { }

--- a/contracts/NodeDelegator.sol
+++ b/contracts/NodeDelegator.sol
@@ -8,6 +8,7 @@ import { LRTConfigRoleChecker, ILRTConfig } from "./utils/LRTConfigRoleChecker.s
 import { INodeDelegator } from "./interfaces/INodeDelegator.sol";
 import { IStrategy } from "./interfaces/IStrategy.sol";
 import { IEigenStrategyManager } from "./interfaces/IEigenStrategyManager.sol";
+import { IOETH } from "./interfaces/IOETH.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
@@ -235,6 +236,11 @@ contract NodeDelegator is INodeDelegator, LRTConfigRoleChecker, PausableUpgradea
         }
 
         emit ETHDepositFromDepositPool(msg.value);
+    }
+
+    /// @dev opts in for rebase so the asset's token balance will increase
+    function optIn(address asset) external onlyLRTAdmin onlySupportedAsset(asset) {
+        IOETH(asset).rebaseOptIn();
     }
 
     /// @dev allow NodeDelegator to receive ETH rewards

--- a/contracts/interfaces/IOETH.sol
+++ b/contracts/interfaces/IOETH.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.8.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IOETH is IERC20 {
+    function rebaseOptIn() external;
+
+    function rebaseOptOut() external;
+}


### PR DESCRIPTION
* Added `optIn` function to both `LRTDepositPool` and `NodeDelegator` that is protected by by the Admin role
* Added `test_DepositPool_optIn_OETH` and `test_NodeDelegator_optIn_OETH` to the fork tests. These upgrade the contracts and call `optIn` as the admin.