### PR TITLE
Only LRT admin can change oracles

### DIFF
--- a/contracts/oracles/ChainlinkPriceOracle.sol
+++ b/contracts/oracles/ChainlinkPriceOracle.sol
@@ -58,7 +58,7 @@ contract ChainlinkPriceOracle is IPriceFetcher, IAssetPriceFeed, LRTConfigRoleCh
     /// @dev only LRTManager is allowed
     /// @param asset asset address for which oracle price feed needs to be added/updated
     /// @param priceFeed chainlink price feed contract which contains exchange rate info
-    function updatePriceFeedFor(address asset, address priceFeed) external onlyLRTManager onlySupportedAsset(asset) {
+    function updatePriceFeedFor(address asset, address priceFeed) external onlyLRTAdmin onlySupportedAsset(asset) {
         UtilLib.checkNonZeroAddress(priceFeed);
         assetPriceFeed[asset] = priceFeed;
         emit AssetPriceFeedUpdate(asset, priceFeed);

--- a/test/ChainlinkPriceOracleTest.t.sol
+++ b/test/ChainlinkPriceOracleTest.t.sol
@@ -82,23 +82,23 @@ contract ChainlinkPriceOracleSetPriceFeed is ChainlinkPriceOracleTest {
         priceFeed = new MockPriceAggregator();
     }
 
-    function test_RevertWhenCallerIsNotLRTManager() external {
+    function test_RevertWhenCallerIsNotLRTAdmin() external {
         vm.startPrank(alice);
-        vm.expectRevert(ILRTConfig.CallerNotLRTConfigManager.selector);
+        vm.expectRevert(ILRTConfig.CallerNotLRTConfigAdmin.selector);
         priceOracle.updatePriceFeedFor(address(ethX), address(priceFeed));
         vm.stopPrank();
     }
 
     function test_RevertWhenAssetIsNotSupported() external {
         address randomAddress = address(0x123);
-        vm.startPrank(manager);
+        vm.startPrank(admin);
         vm.expectRevert(ILRTConfig.AssetNotSupported.selector);
         priceOracle.updatePriceFeedFor(randomAddress, address(priceFeed));
         vm.stopPrank();
     }
 
     function test_RevertWhenPriceFeedIsZero() external {
-        vm.startPrank(manager);
+        vm.startPrank(admin);
         vm.expectRevert(UtilLib.ZeroAddressNotAllowed.selector);
         priceOracle.updatePriceFeedFor(address(ethX), address(0));
         vm.stopPrank();
@@ -107,7 +107,7 @@ contract ChainlinkPriceOracleSetPriceFeed is ChainlinkPriceOracleTest {
     function test_SetAssetPriceFeed() external {
         assertEq(priceOracle.assetPriceFeed(address(ethX)), address(0));
 
-        vm.startPrank(manager);
+        vm.startPrank(admin);
         expectEmit();
         emit AssetPriceFeedUpdate(address(ethX), address(priceFeed));
         priceOracle.updatePriceFeedFor(address(ethX), address(priceFeed));
@@ -125,7 +125,7 @@ contract ChainlinkPriceOracleFetchAssetPrice is ChainlinkPriceOracleTest {
         priceOracle.initialize(address(lrtConfig));
         priceFeed = new MockPriceAggregator();
 
-        vm.prank(manager);
+        vm.prank(admin);
         priceOracle.updatePriceFeedFor(address(ethX), address(priceFeed));
     }
 


### PR DESCRIPTION
We want to move actions that could result in a loss of funds to the LRTAdmin role. While we updated the control of the asset oracle on the main oracle, the chainlink oracle contract can support multiple assets, and also has control of which oracle is used for these assets.

This PR updates the chainlink `updatePriceFeedFor` to admin only from manager only.

