### PR TITLE
Fix and change to LST deposit Defender Action

### DIFF
--- a/script/defender-actions/depositAllEL.js
+++ b/script/defender-actions/depositAllEL.js
@@ -44,7 +44,7 @@ const handler = async (event) => {
     nodeDelegator,
     assets,
     index: 0,
-    minDeposit: 0.001,
+    minDeposit: 0.1,
   });
 };
 

--- a/script/hardhat-tasks/deposits.js
+++ b/script/hardhat-tasks/deposits.js
@@ -46,7 +46,7 @@ const depositAllEL = async ({ signer, depositPool, nodeDelegator, assets, minDep
     const balance = await asset.balanceOf(depositPool.address);
     if (balance.gte(minDepositBN)) {
       log(`Will deposit ${formatUnits(balance)} ${symbol}`);
-      depositAssets.push(assetAddress);
+      depositAssets.push(asset.address);
       symbols.push(symbol);
     } else {
       log(`Skipping deposit of ${formatUnits(balance)} ${symbol}`);


### PR DESCRIPTION
# Changes

* fixed bug in Defender Action that deposits LSTs to EigenLayer
* Increased the LST deposit threshold from 0.001 to 0.1

There are no contract changes

# Testing

Run a local forked node

```bash
make node-fork
```

In the `.env` file
* comment out the `DEFENDER_RELAYER_KEY` and `DEFENDER_TEAM_SECRET` env vars
* uncomment `IMPERSONATE=0x5De069482Ac1DB318082477B7B87D59dfB313f91   # Relayer account`

run the `depositEL` Hardhat task against the local forked node

```bash
export DEBUG=prime*
npx hardhat depositEL --symbol OETH --index 0 --min-deposit 1 --network local
```

# Defender Action upload

```bash
cd ./script/defender-actions
# Build the Defender Actions
npx rollup -c

# Export the DEFENDER_TEAM_KEY and DEFENDER_TEAM_SECRET environment variables
export DEFENDER_TEAM_KEY=
export DEFENDER_TEAM_SECRET=
# Alternatively, the following can be used but it will export all env var including DEPLOYER_PRIVATE_KEY
# set -o allexport && source ../../.env && set +o allexport

# The Defender autotask client uses generic env var names so we'll set them first from the values in the .env file
export API_KEY=${DEFENDER_TEAM_KEY}
export API_SECRET=${DEFENDER_TEAM_SECRET}

npx defender-autotask update-code 184e6533-9413-48be-ac01-4a63f87c3035 ./dist/depositAllEL
```